### PR TITLE
Fix for ICE in taskloop

### DIFF
--- a/test/mp_correct/inc/taskloop_ice.mk
+++ b/test/mp_correct/inc/taskloop_ice.mk
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+build: taskloop_ice.$(OBJX)
+
+run:
+	@echo ------------ executing test $@
+	-$(RUN2) ./taskloop_ice.$(EXESUFFIX) $(LOG)
+
+verify: ;
+
+taskloop_ice.$(OBJX): $(SRC)/taskloop_ice.f90 check.$(OBJX)
+	@echo ------------ building test $@
+	-$(FC) $(FFLAGS) $(SRC)/taskloop_ice.f90
+	@$(RM) ./a.$(EXESUFFIX)
+	-$(FC) $(LDFLAGS) taskloop_ice.$(OBJX) check.$(OBJX) $(LIBS) -o taskloop_ice.$(EXESUFFIX)
+

--- a/test/mp_correct/lit/taskloop_ice.sh
+++ b/test/mp_correct/lit/taskloop_ice.sh
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/mp_correct/src/taskloop_ice.f90
+++ b/test/mp_correct/src/taskloop_ice.f90
@@ -1,0 +1,30 @@
+!
+! Copyright (c) 2019, Arm Ltd.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+program reproducer_taskloop
+    integer, parameter :: n=10
+    integer :: expect(n) = (/ 1,2,3,4,5,6,7,8,9,10 /)
+    integer :: result(n)
+
+    integer :: i
+    result = 2
+    !$OMP TASKLOOP private(i) shared(result)
+    do i = 1, 10
+      result(i) = i
+    end do
+    !$OMP END TASKLOOP
+
+    call check(result,expect,n)
+end program reproducer_taskloop

--- a/tools/flang1/flang1exe/vsub.c
+++ b/tools/flang1/flang1exe/vsub.c
@@ -106,6 +106,7 @@ rewrite_forall(void)
       set_descriptor_sc(SC_PRIVATE);
       break;
     case A_MP_ENDTASK:
+    case A_MP_ETASKLOOP:
       --task_depth;
       if (parallel_depth == 0 && task_depth == 0) {
         set_descriptor_sc(SC_LOCAL);


### PR DESCRIPTION
Add missing case statement for end of Taskloop. Absence of this
case statement leads to some variables being marked as private
(instead of local). This prevents the allocation of these modules
on the stack and their further use in load or store statements.
This patch fixes https://github.com/flang-compiler/flang/issues/688.